### PR TITLE
Cleanup POM files for service module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,24 @@
     <module>packaging</module>
   </modules>
   <properties>
-    <maven.compiler.target>1.7</maven.compiler.target>
-    <maven.compiler.source>1.7</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <org.exoplatform.depmgt.version>11-SNAPSHOT</org.exoplatform.depmgt.version>
     <platform.version>4.3.x-SNAPSHOT</platform.version>
     <juzu.version>1.1.0-M1</juzu.version>
-    <hibernate.version>4.1.12.Final</hibernate.version>
     <org.antlr.version>3.4</org.antlr.version>
+    <org.elasticsearch.version>1.7.2</org.elasticsearch.version>
+    <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 needed by JCR (Only working with impl version < 0.20.6) -->
+    <lucene.version>4.10.4</lucene.version>
+    <!-- Tests -->
+    <mockito.version>2.0.13-beta</mockito.version>
+    <httpclient.version>4.1.2</httpclient.version>
+    <hamcrest.version>1.3</hamcrest.version>
+    <hsqldb.version>2.3.2</hsqldb.version>
+    <logback.version>1.1.3</logback.version>
+    <version.liquibase.plugin>3.4.1</version.liquibase.plugin>
+    <!-- ES Tests -->
+    <elasticsearch-mapper-attachments.version>2.7.1</elasticsearch-mapper-attachments.version>
+    <randomizedtesting-runner.version>2.1.14</randomizedtesting-runner.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -61,6 +71,34 @@
         <artifactId>exo-es-search-service</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.lucene</groupId>
+        <artifactId>lucene-core</artifactId>
+        <version>${lucene.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.liquibase</groupId>
+          <artifactId>liquibase-maven-plugin</artifactId>
+          <version>${version.liquibase.plugin}</version>
+          <configuration>
+            <!-- $ mvn liquibase:update -->
+            <driver>org.hsqldb.jdbcDriver</driver>
+            <url>jdbc:hsqldb:file:target/hsql-db</url>
+            <username>sa</username>
+            <password />
+            <!-- $ mvn liquibase:diff -->
+            <referenceDriver>org.hsqldb.jdbcDriver</referenceDriver>
+            <referenceUrl>jdbc:hsqldb:file:target/hsql-db</referenceUrl>
+            <referenceUsername>sa</referenceUsername>
+            <referencePassword />
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -7,24 +7,6 @@
     <version>1.0.x-SNAPSHOT</version>
   </parent>
   <artifactId>exo-es-search-service</artifactId>
-  <properties>
-    <!-- Issue with the PLF pom parent that trigger lucene 3.6.2 (Only working with impl version < 0.20.6) -->
-    <elasticsearch.version>1.7.0</elasticsearch.version>
-    <elasticsearch-mapper-attachments.version>2.7.1</elasticsearch-mapper-attachments.version>
-    <lucene.version>4.10.4</lucene.version>
-    <randomizedtesting-runner.version>2.1.14</randomizedtesting-runner.version>
-    <mockito.version>2.0.13-beta</mockito.version>
-  </properties>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-core</artifactId>
-        <version>4.10.4</version>
-        <scope>test</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
   <dependencies>
     <!-- PLF dependencies -->
     <dependency>
@@ -63,7 +45,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.1.2</version>
+      <version>${httpclient.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -72,7 +54,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.1.3</version>
+      <version>${logback.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- TEST -->
@@ -84,7 +66,7 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.2</version>
+      <version>${hsqldb.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -95,7 +77,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -120,14 +102,13 @@
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>${elasticsearch.version}</version>
+      <version>${org.elasticsearch.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>${elasticsearch.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -146,35 +127,15 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-maven-plugin</artifactId>
-        <version>3.3.2</version>
         <configuration>
-          <!-- $ mvn liquibase:update -->
-          <driver>org.hsqldb.jdbcDriver</driver>
-          <url>jdbc:hsqldb:file:target/hsql-db</url>
-          <username>sa</username>
-          <password />
-          <!-- $ mvn liquibase:diff -->
-          <referenceDriver>org.hsqldb.jdbcDriver</referenceDriver>
-          <referenceUrl>jdbc:hsqldb:file:target/hsql-db</referenceUrl>
-          <referenceUsername>sa</referenceUsername>
-          <referencePassword />
           <!-- db.changelog file -->
-          <changeLogFile>src/main/resources/db/changelog/exo-search.db.changelog-1.0.0.xml</changeLogFile>
+          <changeLogFile>${project.basedir}/src/main/resources/db/changelog/exo-search.db.changelog-1.0.0.xml</changeLogFile>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This PR includes the following updates:
* specify all dependencies versions as **properties** in the reactor POM
* declare the `liquibase-maven-plugin` in the `<pluginManagement>` section
* remove `maven-compiler-plugin` section (already defined in the eXo maven-parent-pom)
* remove useless properties (already defined in the eXo maven-parent-pom)
* rename ES property from `elasticsearch.version` to **`org.elasticsearch.version`** to be consistent with eXo maven-parent-pom and to be able to test a new ES version easily as follow:
 `mvn verify -Dorg.elasticsearch.version=1.7.3`
